### PR TITLE
Fix/fix articles order when access from categories list

### DIFF
--- a/ui/static/date-order.js
+++ b/ui/static/date-order.js
@@ -9,5 +9,5 @@ dateOrderList.addEventListener('change', (e) => {
   var queryString = Object.keys(params).map(function (key) {
     return key + '=' + params[key]
   }).join('&');
-  location.replace(location.origin + '?' + queryString)
+  location.replace(location.pathname + '?' + queryString)
 })


### PR DESCRIPTION
* Modificar `date-order.js` para que no redirija a la página inicial sino que redirija según el path en caso de acceder a vista de lista de articulos desde lista de categorías