### PR TITLE
Fix/home articles images size

### DIFF
--- a/ui/static/articles.scss
+++ b/ui/static/articles.scss
@@ -12,7 +12,7 @@
   margin-bottom: 2em;
   margin-left: 2em;
   grid-column-gap: 1em;
-  min-height: 250px;
+  height: 100%;
   margin: 15px;
 
   &__title {
@@ -77,7 +77,7 @@
   &__image {
     grid-area: image;
     max-width: 100%;
-    height: 100%;
+    max-height: 250px;
     overflow: hidden;
     border-radius: 0.5rem;
 
@@ -110,7 +110,7 @@
       border-radius: 8px;
       margin-bottom: .5rem;
 
-      font-size: $font-size-m;
+      font-size: $font-size-m - 0.4rem;
       @include desktop {
         font-size: $font-size-d;
       }

--- a/ui/static/articles.scss
+++ b/ui/static/articles.scss
@@ -83,7 +83,7 @@
 
     img {
       width: 100%;
-      height: 100%;
+      max-height: 100%;
       object-fit: cover;
       object-position: center;
     }

--- a/ui/static/articles.scss
+++ b/ui/static/articles.scss
@@ -83,9 +83,17 @@
 
     img {
       width: 100%;
-      max-height: 100%;
+      height: 100%;
       object-fit: cover;
       object-position: center;
+
+      @include desktop {
+        max-height: 100%;
+      }
+
+      @include largeDesktop {
+         max-height: 100%;
+      }
     }
   }
   &__categories {

--- a/ui/static/detail.scss
+++ b/ui/static/detail.scss
@@ -10,7 +10,10 @@
     display: block;
     margin: 0 auto;
     border-radius: 0.5rem;
-    height: 400px;
+    width: 100%;
+    height: 250px;
+    object-fit: cover;
+    object-position: center;
 }
 
 .article-detail__author {

--- a/ui/static/detail.scss
+++ b/ui/static/detail.scss
@@ -11,7 +11,7 @@
     margin: 0 auto;
     border-radius: 0.5rem;
     width: 100%;
-    height: 250px;
+    height: 400px;
     object-fit: cover;
     object-position: center;
 }


### PR DESCRIPTION
* Arreglar tamaño de las imagenes en `Home` y en `Detail` para móvil y escritorio

### Home (Escritorio)
![image](https://user-images.githubusercontent.com/8292424/67163516-37d36b80-f370-11e9-8189-9335cad1bd99.png)

### Home (Movil)
![image](https://user-images.githubusercontent.com/8292424/67163617-45d5bc00-f371-11e9-896e-91ed9f45432b.png)

### Detalles
![image](https://user-images.githubusercontent.com/8292424/67163633-69990200-f371-11e9-9191-834f38cf21a4.png)
