### PR TITLE
Fix/error when redirect to detal view after saving article

### DIFF
--- a/articles/views/detail.py
+++ b/articles/views/detail.py
@@ -66,7 +66,8 @@ class CommentsView(View):
 class FavoriteView(View):
     def post(self, request, slug=None):
         FavoriteController.add_favorite(request=request, slug=slug)
-        return redirect('article_detail', username=request.user, slug=slug)
+        article = get_object_or_404(Article, slug=slug)
+        return redirect('article_detail', username=article.author, slug=slug)
 
 
 class ResponseToView(View):


### PR DESCRIPTION
* Arreglar problema al guardar un articulo de otro autor en favorito y este problema surge a raiz de un fix posterior a esta historia: https://trello.com/c/uYao3JyE/84-qapub-es-posible-acceder-al-mismo-art%C3%ADculo-cambiando-en-la-url-el-username-de-otro `Es posible acceder al mismo artículo cambiando en la URL el username de otro`