### PR TITLE
fix/Fix error when comment a article and whe respond with an article

### DIFF
--- a/articles/views/detail.py
+++ b/articles/views/detail.py
@@ -60,7 +60,8 @@ class ArticleDetailView(View):
 class CommentsView(View):
     def post(self, request, slug=None):
         CommentsController.create_new_comment(request=request, slug=slug)
-        return redirect('article_detail', username=request.user, slug=slug)
+        article = get_object_or_404(Article, slug=slug)
+        return redirect('article_detail', username=article.author, slug=slug)
 
 
 class FavoriteView(View):
@@ -73,4 +74,5 @@ class FavoriteView(View):
 class ResponseToView(View):
     def post(self, request, slug=None):
         CreateArticle.create_new_article(request=request, slug=slug)
-        return redirect('article_detail', username=request.user, slug=slug)
+        article = get_object_or_404(Article, slug=slug)
+        return redirect('article_detail', username=article.author, slug=slug)


### PR DESCRIPTION
* Arreglar fallo cuando comentas articulo o respondes con un articulo, este error surge a raiz de un fix posterior de evitar el acceso a la URL de detalle si el username no corresponde con el autor del articulo
Esta relacionado con otro fix https://trello.com/c/YiQAA8hv/99-pub-que-guardar-articulo-de-otro-autor-como-favorito-no-de-error-al-redireccionar-a-la-pagina-de-detalle